### PR TITLE
Added owner-email overriding for form compat

### DIFF
--- a/test/fixtures/mail_handler/form_compat_ticket_by_unknown_user_w_override.eml
+++ b/test/fixtures/mail_handler/form_compat_ticket_by_unknown_user_w_override.eml
@@ -1,0 +1,20 @@
+Return-Path: <form@somenet.foo>
+Received: from osiris ([127.0.0.1])
+	by OSIRIS
+	with hMailServer ; Sun, 22 Jun 2008 12:28:07 +0200
+Message-ID: <000501c8d452$a95cd7e0$0a00a8c0@osiris>
+From: "FormRelay" <form@somenet.foo>
+To: <redmine@somenet.foo>
+Subject: Ticket by unknown user w override
+Date: Sun, 22 Jun 2008 12:28:07 +0200
+MIME-Version: 1.0
+Content-Type: text/plain;
+	format=flowed;
+	charset="iso-8859-1";
+	reply-type=original
+Content-Transfer-Encoding: 7bit
+
+Owner-email: john.doe@somenet.foo
+
+This is a ticket submitted by an unknown user.
+

--- a/test/fixtures/mail_handler/form_compat_ticket_by_user_1_w_override.eml
+++ b/test/fixtures/mail_handler/form_compat_ticket_by_user_1_w_override.eml
@@ -1,0 +1,20 @@
+Return-Path: <form@somenet.foo>
+Received: from osiris ([127.0.0.1])
+	by OSIRIS
+	with hMailServer ; Sun, 22 Jun 2008 12:28:07 +0200
+Message-ID: <000501c8d452$a95cd7e0$0a00a8c0@osiris>
+From: "FormRelay" <form@somenet.foo>
+To: <redmine@somenet.foo>
+Subject: Ticket by user w override
+Date: Sun, 22 Jun 2008 12:28:07 +0200
+MIME-Version: 1.0
+Content-Type: text/plain;
+	format=flowed;
+	charset="iso-8859-1";
+	reply-type=original
+Content-Transfer-Encoding: 7bit
+
+Owner-email: rhill@somenet.foo
+
+This is a ticket submitted by an unknown user.
+

--- a/test/fixtures/mail_handler/form_compat_ticket_by_user_2_w_override.eml
+++ b/test/fixtures/mail_handler/form_compat_ticket_by_user_2_w_override.eml
@@ -1,0 +1,20 @@
+Return-Path: <form@somenet.foo>
+Received: from osiris ([127.0.0.1])
+	by OSIRIS
+	with hMailServer ; Sun, 22 Jun 2008 12:28:07 +0200
+Message-ID: <000501c8d452$a95cd7e0$0a00a8c0@osiris>
+From: "FormRelay" <form@somenet.foo>
+To: <redmine@somenet.foo>
+Subject: Ticket by unknown user w override
+Date: Sun, 22 Jun 2008 12:28:07 +0200
+MIME-Version: 1.0
+Content-Type: text/plain;
+	format=flowed;
+	charset="iso-8859-1";
+	reply-type=original
+Content-Transfer-Encoding: 7bit
+
+Owner-email: dlopper@somenet.foo
+
+This is a ticket submitted by a supportclient.
+


### PR DESCRIPTION
Using embedded forms on a website requires either sender spoofing
or owner-email overwriting. With the added overriding support the
latter is now possible:

  - Standard get_keyword function is used to parse the
    "Owner-email:" value
  - Non-anonymous supportclients are supported
  - Overriding respects the allow_override option